### PR TITLE
Check PermissionAttachmentInfo value on changeCooldownByPermission

### DIFF
--- a/src/me/Darrionat/CommandCooldown/listeners/CommandProcess.java
+++ b/src/me/Darrionat/CommandCooldown/listeners/CommandProcess.java
@@ -99,6 +99,8 @@ public class CommandProcess implements Listener {
 	private double changeCooldownByPermission(Command command, Player p, double duration) {
 		// Has permission with different cooldown
 		for (PermissionAttachmentInfo permissionAttachmentInfo : p.getEffectivePermissions()) {
+			if (!permissionAttachmentInfo.getValue()) continue;
+
 			String permission = permissionAttachmentInfo.getPermission();
 			String key = command.message.replace(" ", "_");
 			if (!permission.contains("commandcooldown." + key)) {


### PR DESCRIPTION
Now when changeColorByPermission is called, it checks if the permission value is true or false. 