### PR TITLE
Add api-version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.darrionat</groupId>
     <artifactId>CommandCooldown</artifactId>
-    <version>2.3.4</version>
+    <version>2.3.5</version>
     <repositories>
         <repository>
             <id>spigot-repo</id>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: CommandCooldown
 main: me.darrionat.commandcooldown.CommandCooldownPlugin
 description: An easy way to add cooldowns to commands
-version: 2.3.4
+version: 2.3.5
 api-version: 1.16
 
 commands:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: CommandCooldown
 main: me.darrionat.commandcooldown.CommandCooldownPlugin
 description: An easy way to add cooldowns to commands
 version: 2.3.4
+api-version: 1.16
 
 commands:
   commandcooldown:


### PR DESCRIPTION
Add api-version to get rid of 
`[WARN]: Initializing Legacy Material Support. Unless you have legacy plugins and/or data this is a bug!`
`[WARN]: Legacy plugin CommandCooldown v2.3.4 does not specify an api-version.`