### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Command Cooldown 1.7-1.17
+# Command Cooldown 1.7-1.19
 
 Created by [Darrion][Darrionat], CommandCooldown is a Spigot plugin is capable of adding cooldowns to any command. Originally published in December 2019,
 CommandCooldown has gone through a multitude of changes to end where it is.

--- a/pom.xml
+++ b/pom.xml
@@ -26,19 +26,19 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <version>1.19.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- PluginLib -->
         <dependency>
             <groupId>com.github.darrionat.PluginLib</groupId>
             <artifactId>core</artifactId>
-            <version>1.4.3</version>
+            <version>1.7.1</version>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui</artifactId>
-            <version>1.5.1-SNAPSHOT</version>
+            <version>1.5.3-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies> <!-- Added for snapshots-->
@@ -74,7 +74,7 @@
         </plugins>
     </build>
     <properties>
-        <java.version>1.16</java.version>
+        <java.version>1.17</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>


### PR DESCRIPTION
The plugin seems to already work on 1.19+, so this pr just updates the dependencies and marks 1.19 as supported in the README.

I guess you could just fix the minor issues that are currently reported here on GitHub and release it as 2.5.1 if you have nothing else planned and then add 1.18 and 1.19 to the supported versions on Spigot so that it doesn't look like the plugin was abandoned/is dead or something?

Cheers,
Chris6ix